### PR TITLE
Fix for slimnet output

### DIFF
--- a/tf/FDFE.py
+++ b/tf/FDFE.py
@@ -32,6 +32,9 @@ class unwrapPrepare(tf.keras.layers.Layer):
 
     def call(self, input):
         x = tf.slice(input, self.crop, [input.shape[0], input.shape[1] - 1, input.shape[2] - 1, input.shape[3]])
+        
+        # Below Line is necessary to map pytorch code to tensorflow, as pytorch follows channels-first format
+        x = tf.keras.layers.Permute((3, 1, 2))(x)
         x = tf.reshape(x, [x.shape[0], -1], name='unwrapPrepare_reshape')
         # y = x
         y = tf.transpose(x)


### PR DESCRIPTION
Issue: patch-based output (basenet) was not matching image-based output (slimnet)
Reason and Fix: Pytorch code follows channels-first format throughout, but tensorflow code follows channels-last format untill unwrapPrepare. From there and onwards, it's output shapes matche with pytorch. So, for this conversion, the added line converts channels-last to channels-first compatible format.